### PR TITLE
Modify remove-ads.js to select set of classes to match the ads as the…

### DIFF
--- a/src/remove-ads.js
+++ b/src/remove-ads.js
@@ -1,4 +1,4 @@
-var ads = document.getElementsByClassName('ad-iindicator');
+var ads = document.getElementsByClassName('position-absolute position-top ml-xs-1 mt-xs-1 normal z-index-1');
 
 // Polyfill Element.prototype.matches
 if (!Element.prototype.matches) {


### PR DESCRIPTION
The class used to set the `ads` variable in `remove-ads.js` is no longer used on Etsy. I noticed this when I was porting this over to FireFox, some people also mentioned it in the reviews. I've patched it to select a set of classes that the ads now have in them. It seems to be working if you'd like to test it out and merge the change. 